### PR TITLE
Update settings_basic.conf

### DIFF
--- a/examples/simpleapp/src/main/resources/settings_basic.conf
+++ b/examples/simpleapp/src/main/resources/settings_basic.conf
@@ -18,7 +18,9 @@ scorex {
 	  address = "ws://localhost:8888"
 	  connectionTimeout = 100 milliseconds
 	  reconnectionDelay = 1 seconds
-    reconnectionMaxAttempts = 1
+	  reconnectionMaxAttempts = 1
+	  zencliCommandLine = ""
+	  zencliCommandLineArguments = []
   }
 
   withdrawalEpochCertificate {


### PR DESCRIPTION
Added two missing keys to websocket to prevent the following error : 

Exception in thread "main" com.typesafe.config.ConfigException$Missing: No configuration setting found for key 'scorex.websocket.zencliCommandLine'